### PR TITLE
Unfuck sessions when deploying to heroku

### DIFF
--- a/.flaskenv
+++ b/.flaskenv
@@ -2,3 +2,4 @@ APP_SETTINGS="config.DevelopmentConfig"
 DATABASE_URL="postgresql://localhost/kvasir_dev"
 FLASK_APP=app
 FLASK_ENV=development
+SECRET_KEY=secret_key

--- a/config.py
+++ b/config.py
@@ -3,6 +3,7 @@ import os
 class Config(object):
     ENV = None
     DEBUG = False
+    SECRET_KEY = os.environ['SECRET_KEY']
     SQLALCHEMY_DATABASE_URI = os.environ['DATABASE_URL']
     TESTING = False
 
@@ -18,4 +19,3 @@ class DevelopmentConfig(Config):
     DEBUG = True
     ENV = 'development'
     TESTING = True
-    SECRET_KEY = 'default_secret'


### PR DESCRIPTION
SECRET_KEY needs to be settable on all deploys, so moving it to the root config is good